### PR TITLE
update dependencies

### DIFF
--- a/index.litcoffee
+++ b/index.litcoffee
@@ -56,7 +56,12 @@ will iteratively update on changes
         destDir = path.dirname(dest)
         ->
             gutil.log("GulpHelpers.Browserify -- task started for #{destFileName}")
-            watcher = watchify(browserify(src, watchify.args))
+            watcher = browserify({
+                entries: src
+                cache: {}
+                packageCache: {}
+                plugin: [watchify]
+            })
             rebundle = ->
                 gutil.log "GulpHelpers.Browserify -- Watcher for #{destFileName} triggered update"
                 watcherStream = watcher.bundle()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-cs-helper",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A module to demonstrate a typical Coffeescript gulp compilation workflow.",
   "main": "index.js",
   "scripts": {
@@ -14,7 +14,7 @@
   "author": "Greg Hart",
   "license": "ISC",
   "dependencies": {
-    "browserify": "5.9.x",
+    "browserify": "14.4.x",
     "coffee-script": "1.7.x",
     "gulp": "3.8.6",
     "gulp-cached": "^1.0.1",
@@ -26,7 +26,7 @@
     "gulp-util": "^3.0.0",
     "underscore": "^1.7.0",
     "vinyl-source-stream": "^0.1.1",
-    "watchify": "^3.3.1"
+    "watchify": "^3.9.0"
   },
   "devDependencies": {
     "coffee-script": "^1.7.1"


### PR DESCRIPTION
Older version of watchify was getting node-gyp compilation errors on fsevents when using node6.